### PR TITLE
added handling for X11 Forwarding

### DIFF
--- a/pkg/bastion/session.go
+++ b/pkg/bastion/session.go
@@ -34,7 +34,6 @@ type sessionConfig struct {
 }
 
 func multiChannelHandler(conn *gossh.ServerConn, newChan gossh.NewChannel, ctx ssh.Context, configs []sessionConfig, sessionID uint) error {
-	log.Printf("MultiChannelHandler: ChannelType: %s \n", newChan.ChannelType())
 	var lastClient *gossh.Client
 	switch newChan.ChannelType() {
 	case "session":


### PR DESCRIPTION
This changes enables X11 Forwarding.
The routines ForwardToRemoteX11 and ForwardToRemote could possibly be merged to on, but i couldn't not test again forwarding, therefore i did not touch it.

<!-- thank you for your contribution! ❤️  -->
